### PR TITLE
Corruption Patch

### DIFF
--- a/src/main/java/UniversalCardFix/Utils.java
+++ b/src/main/java/UniversalCardFix/Utils.java
@@ -8,6 +8,8 @@ import java.lang.reflect.Field;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 
+import org.apache.logging.log4j.Logger;
+
 public class Utils {
     public static void relicAddToTop(AbstractGameAction action) {
         AbstractDungeon.actionManager.addToTop(action);
@@ -88,4 +90,10 @@ public class Utils {
         card.upgradedMagicNumber = true;
     }
 
+    public static void corruptionCostModify(Logger logger, AbstractCard card) {
+        logger.info("modifying: " + card.name);
+        logger.info("costs before: cost = " + card.cost + ", costForTurn = " + card.costForTurn);
+        card.modifyCostForCombat(-1);
+        logger.info("costs after: cost = " + card.cost + ", costForTurn = " + card.costForTurn);
+    }
 }

--- a/src/main/java/UniversalCardFix/patches/actions/common/ApplyPowerActionPatch.java
+++ b/src/main/java/UniversalCardFix/patches/actions/common/ApplyPowerActionPatch.java
@@ -1,0 +1,196 @@
+package UniversalCardFix.patches.actions.common;
+
+import UniversalCardFix.Utils;
+
+import com.megacrit.cardcrawl.core.Settings;
+import com.evacipated.cardcrawl.modthespire.lib.SpirePatch;
+import com.evacipated.cardcrawl.modthespire.lib.SpireInsertPatch;
+import com.megacrit.cardcrawl.actions.common.ApplyPowerAction;
+import com.megacrit.cardcrawl.actions.AbstractGameAction;
+import com.megacrit.cardcrawl.cards.AbstractCard;
+import com.megacrit.cardcrawl.dungeons.AbstractDungeon;
+import com.megacrit.cardcrawl.core.AbstractCreature;
+import com.megacrit.cardcrawl.powers.AbstractPower;
+
+import java.util.UUID;
+import java.util.HashMap;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+
+public class ApplyPowerActionPatch {
+    public static final Logger logger = LogManager.getLogger(ApplyPowerActionPatch.class.getName());
+
+    private static void corruptionCostModify(AbstractCard c) {
+        Utils.corruptionCostModify(logger, c);
+    }
+
+    public static class Costs {
+        public int cost;
+        public int costForTurn;
+
+        public Costs(int cost, int costForTurn) {
+            this.cost = cost;
+            this.costForTurn = costForTurn;
+        }
+
+        public void resetCosts(AbstractCard card) {
+            card.cost = this.cost;
+            card.costForTurn = this.costForTurn;
+        }
+    }
+
+    @SpirePatch(
+        clz = ApplyPowerAction.class,
+        method = SpirePatch.CONSTRUCTOR,
+        paramtypez={
+            AbstractCreature.class,
+            AbstractCreature.class,
+            AbstractPower.class,
+            int.class,
+            boolean.class,
+            AbstractGameAction.AttackEffect.class
+        }
+    )
+    public static class Constructor {
+        private static HashMap<UUID, Costs> handSkills = new HashMap<UUID, Costs>();
+        private static HashMap<UUID, Costs> drawSkills = new HashMap<UUID, Costs>();
+        private static HashMap<UUID, Costs> discardSkills = new HashMap<UUID, Costs>();
+        private static HashMap<UUID, Costs> exhaustSkills = new HashMap<UUID, Costs>();
+
+        public static void Prefix(ApplyPowerAction __instance, AbstractCreature target, AbstractCreature source, AbstractPower powerToApply, int stackAmount, boolean isFast, AbstractGameAction.AttackEffect effect) {
+            if (powerToApply.ID.equals("Corruption")) {
+                logger.info("ApplyPowerActionPatch: Corruption Prefix");
+
+                for (AbstractCard c : AbstractDungeon.player.hand.group) {
+                    if (c.type != AbstractCard.CardType.SKILL) continue;
+                    handSkills.put(c.uuid, new Costs(c.cost, c.costForTurn));
+                }
+                for (AbstractCard c : AbstractDungeon.player.drawPile.group) {
+                    if (c.type != AbstractCard.CardType.SKILL) continue;
+                    drawSkills.put(c.uuid, new Costs(c.cost, c.costForTurn));
+                }
+                for (AbstractCard c : AbstractDungeon.player.discardPile.group) {
+                    if (c.type != AbstractCard.CardType.SKILL) continue;
+                    discardSkills.put(c.uuid, new Costs(c.cost, c.costForTurn));
+                }
+                for (AbstractCard c : AbstractDungeon.player.exhaustPile.group) {
+                    if (c.type != AbstractCard.CardType.SKILL) continue;
+                    exhaustSkills.put(c.uuid, new Costs(c.cost, c.costForTurn));
+                }
+            }
+        }
+
+        public static void Postfix(ApplyPowerAction __instance, AbstractCreature target, AbstractCreature source, AbstractPower powerToApply, int stackAmount, boolean isFast, AbstractGameAction.AttackEffect effect) {
+            if (powerToApply.ID.equals("Corruption")) {
+                logger.info("ApplyPowerActionPatch: Corruption Postfix");
+
+                for (AbstractCard c : AbstractDungeon.player.hand.group) {
+                    if (c.type != AbstractCard.CardType.SKILL) continue;
+                    Costs costs = handSkills.get(c.uuid);
+                    costs.resetCosts(c);
+                    corruptionCostModify(c);
+                }
+                for (AbstractCard c : AbstractDungeon.player.drawPile.group) {
+                    if (c.type != AbstractCard.CardType.SKILL) continue;
+                    Costs costs = drawSkills.get(c.uuid);
+                    costs.resetCosts(c);
+                    corruptionCostModify(c);
+                }
+                for (AbstractCard c : AbstractDungeon.player.discardPile.group) {
+                    if (c.type != AbstractCard.CardType.SKILL) continue;
+                    Costs costs = discardSkills.get(c.uuid);
+                    costs.resetCosts(c);
+                    corruptionCostModify(c);
+                }
+                for (AbstractCard c : AbstractDungeon.player.exhaustPile.group) {
+                    if (c.type != AbstractCard.CardType.SKILL) continue;
+                    Costs costs = exhaustSkills.get(c.uuid);
+                    costs.resetCosts(c);
+                    corruptionCostModify(c);
+                }
+            }
+        }
+    }
+/*
+             if (powerToApply.ID.equals("Corruption")) {
+                for (AbstractCard c : AbstractDungeon.player.hand.group) {
+                    if (c.type != AbstractCard.CardType.SKILL) continue;
+                    corruptionCostModify(c);
+                }
+                for (AbstractCard c : AbstractDungeon.player.drawPile.group) {
+                    if (c.type != AbstractCard.CardType.SKILL) continue;
+                    corruptionCostModify(c);
+                }
+                for (AbstractCard c : AbstractDungeon.player.discardPile.group) {
+                    if (c.type != AbstractCard.CardType.SKILL) continue;
+                    corruptionCostModify(c);
+                }
+                for (AbstractCard c : AbstractDungeon.player.exhaustPile.group) {
+                    if (c.type != AbstractCard.CardType.SKILL) continue;
+                    corruptionCostModify(c);
+                }
+            }
+*/
+/*
+    @SpirePatch(
+        clz = ApplyPowerAction.class,
+        method = SpirePatch.CONSTRUCTOR,
+        paramtypez={
+            AbstractCreature.class,
+            AbstractCreature.class,
+            AbstractPower.class,
+            int.class,
+            boolean.class,
+            AbstractGameAction.AttackEffect.class
+        }
+    )
+    public static class Constructor {
+        public static void Prefix(ApplyPowerAction __instance, AbstractCreature target, AbstractCreature source, AbstractPower powerToApply, int stackAmount, boolean isFast, AbstractGameAction.AttackEffect effect, AbstractPower ___powerToApply, float ___startingDuration, float ___duration) {
+            logger.info("Running Corruption Constructor Prefix");
+            ___startingDuration = Settings.FAST_MODE ? 0.1f : (isFast ? Settings.ACTION_DUR_FASTER : Settings.ACTION_DUR_FAST);
+            //__instance.setValues(target, source, stackAmount);
+            __instance.target = target;
+            __instance.source = source;
+            __instance.amount = stackAmount;
+            ___duration = ___startingDuration;
+            ___powerToApply = powerToApply;
+            if (AbstractDungeon.player.hasRelic("Snake Skull") && source != null && source.isPlayer && target != source && powerToApply.ID.equals("Poison")) {
+                AbstractDungeon.player.getRelic("Snake Skull").flash();
+                ++___powerToApply.amount;
+                ++__instance.amount;
+            }
+
+            __instance.actionType = AbstractGameAction.ActionType.POWER;
+            __instance.attackEffect = effect;
+            if (AbstractDungeon.getMonsters().areMonstersBasicallyDead()) {
+                ___duration = 0.0f;
+                ___startingDuration = 0.0f;
+                __instance.isDone = true;
+            }
+
+            if (powerToApply.ID.equals("Corruption")) {
+                for (AbstractCard c : AbstractDungeon.player.hand.group) {
+                    if (c.type != AbstractCard.CardType.SKILL) continue;
+                    corruptionCostModify(c);
+                }
+                for (AbstractCard c : AbstractDungeon.player.drawPile.group) {
+                    if (c.type != AbstractCard.CardType.SKILL) continue;
+                    corruptionCostModify(c);
+                }
+                for (AbstractCard c : AbstractDungeon.player.discardPile.group) {
+                    if (c.type != AbstractCard.CardType.SKILL) continue;
+                    corruptionCostModify(c);
+                }
+                for (AbstractCard c : AbstractDungeon.player.exhaustPile.group) {
+                    if (c.type != AbstractCard.CardType.SKILL) continue;
+                    corruptionCostModify(c);
+                }
+            }
+
+            return;
+        }
+    }
+*/
+}

--- a/src/main/java/UniversalCardFix/patches/cards/AbstractCardPatch.java
+++ b/src/main/java/UniversalCardFix/patches/cards/AbstractCardPatch.java
@@ -4,6 +4,8 @@ import com.evacipated.cardcrawl.modthespire.lib.SpirePatch;
 import com.evacipated.cardcrawl.modthespire.lib.SpireInsertPatch;
 import com.megacrit.cardcrawl.cards.AbstractCard;
 
+import org.apache.logging.log4j.Logger;
+
 public class AbstractCardPatch {
     @SpirePatch(
         clz = AbstractCard.class,
@@ -18,6 +20,20 @@ public class AbstractCardPatch {
             card.isEthereal = __instance.isEthereal;
             card.rawDescription = __instance.rawDescription;
             card.initializeDescription();
+        }
+    }
+
+    @SpirePatch(
+        clz = AbstractCard.class,
+        method = "modifyCostForCombat"
+    )
+    public static class ModifyCostForCombat {
+        public static void Prefix(AbstractCard __instance, int amt, Logger ___logger) {
+            StackTraceElement[] stackTrace = Thread.currentThread().getStackTrace();
+            // this would be [2], but the patch shifts things down
+            StackTraceElement caller = stackTrace[3];
+            ___logger.info("className = " + caller.getClassName() + ", fileName = " + caller.getFileName() + ", methodName = " + caller.getMethodName() + ", lineNumber = " + caller.getLineNumber());
+            ___logger.info("modifyCostForCombat amount: " + amt);
         }
     }
 }

--- a/src/main/java/UniversalCardFix/patches/characters/AbstractPlayerPatch.java
+++ b/src/main/java/UniversalCardFix/patches/characters/AbstractPlayerPatch.java
@@ -1,0 +1,79 @@
+package UniversalCardFix.patches.actions.common;
+
+import UniversalCardFix.Utils;
+
+import com.megacrit.cardcrawl.core.Settings;
+import com.evacipated.cardcrawl.modthespire.lib.SpirePatch;
+import com.evacipated.cardcrawl.modthespire.lib.SpireInsertPatch;
+import com.megacrit.cardcrawl.actions.common.ApplyPowerAction;
+import com.megacrit.cardcrawl.actions.AbstractGameAction;
+import com.megacrit.cardcrawl.actions.utility.UseCardAction;
+import com.megacrit.cardcrawl.cards.AbstractCard;
+import com.megacrit.cardcrawl.dungeons.AbstractDungeon;
+import com.megacrit.cardcrawl.core.AbstractCreature;
+import com.megacrit.cardcrawl.powers.AbstractPower;
+import com.megacrit.cardcrawl.characters.AbstractPlayer;
+import com.megacrit.cardcrawl.relics.AbstractRelic;
+import com.megacrit.cardcrawl.monsters.AbstractMonster;
+import com.megacrit.cardcrawl.ui.panels.EnergyPanel;
+
+import org.apache.logging.log4j.Logger;
+
+public class AbstractPlayerPatch {
+    @SpirePatch(
+        clz = AbstractPlayer.class,
+        method = "onCardDrawOrDiscard"
+    )
+    public static class OnCardDrawOrDiscard {
+        public static void Prefix(AbstractPlayer __instance, Logger ___logger) {
+            for (AbstractPower p : __instance.powers) {
+                p.onDrawOrDiscard();
+            }
+            for (AbstractRelic r : __instance.relics) {
+                r.onDrawOrDiscard();
+            }
+            if (__instance.hasPower("Corruption")) {
+                for (AbstractCard c : __instance.hand.group) {
+                    if (c.type != AbstractCard.CardType.SKILL || c.costForTurn == 0) continue;
+                    Utils.corruptionCostModify(___logger, c);
+                }
+            }
+            __instance.hand.applyPowers();
+            __instance.hand.glowCheck();
+
+            return;
+        }
+    }
+
+    @SpirePatch(
+        clz = AbstractPlayer.class,
+        method = "useCard"
+    )
+    public static class UseCard {
+        public static void Replace(AbstractPlayer __instance, AbstractCard c, AbstractMonster monster, int energyOnUse) {
+            if (c.type == AbstractCard.CardType.ATTACK) {
+                __instance.useFastAttackAnimation();
+            }
+            c.calculateCardDamage(monster);
+            if (c.cost == -1 && EnergyPanel.totalCount < energyOnUse && !c.ignoreEnergyOnUse) {
+                c.energyOnUse = EnergyPanel.totalCount;
+            }
+            if (c.cost == -1 && c.isInAutoplay) {
+                c.freeToPlayOnce = true;
+            }
+            c.use(__instance, monster);
+            AbstractDungeon.actionManager.addToBottom(new UseCardAction(c, monster));
+            if (!c.dontTriggerOnUseCard) {
+                __instance.hand.triggerOnOtherCardPlayed(c);
+            }
+            __instance.hand.removeCard(c);
+            __instance.cardInUse = c;
+            c.target_x = Settings.WIDTH / 2;
+            c.target_y = Settings.HEIGHT / 2;
+            // Patched here; removes free energy use based on Corruption status
+            if (!(c.costForTurn <= 0 || c.freeToPlay() || c.isInAutoplay)) {
+                __instance.energy.use(c.costForTurn);
+            }
+        }
+    }
+}

--- a/src/main/java/UniversalCardFix/patches/powers/CorruptionPowerPatch.java
+++ b/src/main/java/UniversalCardFix/patches/powers/CorruptionPowerPatch.java
@@ -1,0 +1,29 @@
+package UniversalCardFix.patches.powers;
+
+import UniversalCardFix.Utils;
+
+import com.evacipated.cardcrawl.modthespire.lib.SpirePatch;
+import com.megacrit.cardcrawl.cards.AbstractCard;
+import com.megacrit.cardcrawl.powers.CorruptionPower;
+
+import org.apache.logging.log4j.Logger;
+
+public class CorruptionPowerPatch {
+    @SpirePatch(clz = CorruptionPower.class, method = SpirePatch.CONSTRUCTOR)
+    public static class Constructor {
+        public static void Postfix(CorruptionPower __instance) {
+            __instance.description = "#ySkills cost #b1 less. Whenever you play a #ySkill, #yExhaust it.";
+        }
+    }
+
+    @SpirePatch(clz = CorruptionPower.class, method = "onCardDraw")
+    public static class OnCardDraw {
+        public static void Replace(CorruptionPower __instance, AbstractCard card) {
+            if (card.type == AbstractCard.CardType.SKILL) {
+                card.setCostForTurn(card.cost - 1);
+            }
+
+            return;
+        }
+    }
+}

--- a/src/main/java/UniversalCardFix/patches/vfx/cardManip/ShowCardAndAddToHandEffectPatch.java
+++ b/src/main/java/UniversalCardFix/patches/vfx/cardManip/ShowCardAndAddToHandEffectPatch.java
@@ -1,0 +1,61 @@
+package UniversalCardFix.patches.actions.common;
+
+import UniversalCardFix.Utils;
+
+import com.megacrit.cardcrawl.core.Settings;
+import com.evacipated.cardcrawl.modthespire.lib.SpirePatch;
+import com.evacipated.cardcrawl.modthespire.lib.SpireInsertPatch;
+import com.megacrit.cardcrawl.actions.common.ApplyPowerAction;
+import com.megacrit.cardcrawl.actions.AbstractGameAction;
+import com.megacrit.cardcrawl.cards.AbstractCard;
+import com.megacrit.cardcrawl.dungeons.AbstractDungeon;
+import com.megacrit.cardcrawl.core.AbstractCreature;
+import com.megacrit.cardcrawl.powers.AbstractPower;
+import com.megacrit.cardcrawl.vfx.cardManip.ShowCardAndAddToHandEffect;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+public class ShowCardAndAddToHandEffectPatch {
+    public static final Logger logger = LogManager.getLogger(ShowCardAndAddToHandEffectPatch.class.getName());
+
+    private static void corruptionCostModify(AbstractCard c) {
+        Utils.corruptionCostModify(logger, c);
+    }
+
+    @SpirePatch(
+        clz = ShowCardAndAddToHandEffect.class,
+        method = SpirePatch.CONSTRUCTOR,
+        paramtypez={
+            AbstractCard.class,
+            float.class,
+            float.class
+        }
+    )
+    public static class Constructor1 {
+        public static void Postfix(ShowCardAndAddToHandEffect __instance, AbstractCard card, float offsetX, float offsetY) {
+            logger.info("Running ShowCardAndAddToHandEffect Constructor1 Postfix");
+            if (AbstractDungeon.player.hasPower("Corruption") && card.type == AbstractCard.CardType.SKILL) {
+                card.costForTurn = card.cost; // reset costForTurn
+                corruptionCostModify(card);
+            }
+        }
+    }
+
+    @SpirePatch(
+        clz = ShowCardAndAddToHandEffect.class,
+        method = SpirePatch.CONSTRUCTOR,
+        paramtypez={
+            AbstractCard.class
+        }
+    )
+    public static class Constructor2 {
+        public static void Postfix(ShowCardAndAddToHandEffect __instance, AbstractCard card) {
+            logger.info("Running ShowCardAndAddToHandEffect Constructor2 Postfix");
+            if (AbstractDungeon.player.hasPower("Corruption") && card.type == AbstractCard.CardType.SKILL) {
+                card.costForTurn = card.cost; // reset costForTurn
+                corruptionCostModify(card);
+            }
+        }
+    }
+}


### PR DESCRIPTION
TODO:
- [ ] Power is applied repeatedly any time a skill is played. This is wrong. E.g. if you have in hand a Corruption and two Shockwaves, you play Corruption (and thus both Shockwaves now cost 1), then you play one of the Shockwaves, the Power is triggered again, and the second Shockwave now costs 0. This second reduction shouldn't happen.
- [ ] The effect should stack, e.g. if you play two Corruptions in a combat, Skills now cost two less
- [ ] The description of the card needs to change to reflect its new effect
- [ ] The description of the power needs to update based on the stacking of the effect (i.e. multiple Corruptions are played)
